### PR TITLE
use the full width available for the card

### DIFF
--- a/lib/home_dash_web/components/cards/brew_dash_taps.ex
+++ b/lib/home_dash_web/components/cards/brew_dash_taps.ex
@@ -23,7 +23,7 @@ defmodule HomeDashWeb.Cards.BrewDashTaps do
 
     ~H"""
     <div class={[
-      "flex flex-col bg-white drop-shadow rounded-md col-span-3 relative rounded overflow-hidden shadow-lg max-w-98",
+      "flex flex-col bg-white drop-shadow rounded-md col-span-3 relative rounded overflow-hidden shadow-lg w-full",
       "dark:bg-muted-gray",
       @class
     ]}>


### PR DESCRIPTION
- fixes an issue with some cards being slimmer if they have slimmer images
- fixes overlap on some screen sizes



This looks like it fixes the width issues with the brew card

Before
<img width="1155" alt="Screenshot 2024-02-10 at 15 33 38" src="https://github.com/Baradoy/home_dash/assets/244021/77ee7470-fd60-41bf-94fc-ee62223ce226">

After
<img width="1203" alt="Screenshot 2024-02-10 at 15 36 30" src="https://github.com/Baradoy/home_dash/assets/244021/84e6690e-bb29-4dd3-ac4e-e2050d68e716">
