### PR TITLE
Remove use of custom tailwind colors

### DIFF
--- a/lib/home_dash_web/components/brew_dash_common.ex
+++ b/lib/home_dash_web/components/brew_dash_common.ex
@@ -16,7 +16,9 @@ defmodule HomeDashWeb.BrewDashCommon do
 
     ~H"""
     <div class={[
-      "absolute top-4 py-1 px-4 rounded-full font-bold text-m bg-blue-200 dark:bg-dull-blue dark:border-blue-800",
+      "absolute top-4 py-1 px-4 rounded-full font-bold text-m capitalize",
+      "bg-blue-200",
+      "dark:bg-sky-900",
       @class,
       @position
     ]}>

--- a/lib/home_dash_web/components/cards/brew_dash_taps.ex
+++ b/lib/home_dash_web/components/cards/brew_dash_taps.ex
@@ -23,8 +23,9 @@ defmodule HomeDashWeb.Cards.BrewDashTaps do
 
     ~H"""
     <div class={[
-      "flex flex-col bg-white drop-shadow rounded-md col-span-3 relative rounded overflow-hidden shadow-lg w-full",
-      "dark:bg-muted-gray",
+      "flex flex-col drop-shadow rounded-md col-span-3 relative rounded overflow-hidden shadow-lg w-full",
+      "bg-white",
+      "dark:bg-zinc-700",
       @class
     ]}>
       <div class="overflow-y-auto">


### PR DESCRIPTION
We were using custom tailwind colours copied from the original brewdash card. Replaced with some close proximates