### PR TITLE
Add Provider.State

### DIFF
--- a/lib/home_dash/provider/state.ex
+++ b/lib/home_dash/provider/state.ex
@@ -19,7 +19,6 @@ defmodule HomeDash.Provider.State do
   @type cards() :: list(HomeDash.Card.t())
   @type cards_response() :: {t(), cards(), cards()}
 
-  @enforce_keys [:opts, :cards, :subscriptions]
   defstruct opts: [], cards: %{}, subscriptions: []
 
   @spec add_cards(t(), cards()) :: cards_response()
@@ -32,7 +31,7 @@ defmodule HomeDash.Provider.State do
   end
 
   @spec new(opts()) :: t()
-  def new(opts), do: %__MODULE__{opts: opts, cards: %{}, subscriptions: []}
+  def new(opts), do: %__MODULE__{opts: opts}
 
   @spec set_cards(t(), cards()) :: cards_response()
   def set_cards(state, new_cards) do

--- a/lib/home_dash/provider/state.ex
+++ b/lib/home_dash/provider/state.ex
@@ -1,0 +1,74 @@
+defmodule HomeDash.Provider.State do
+  @moduledoc """
+  State handling for a Provider.
+
+  State includes a list of cards and subscriptions.
+
+  Subscriptions inculde the process id and the component component id for message routing purposes.
+  """
+
+  @type opts() :: term()
+  @type component_id() :: String.t()
+  @type subscription() :: {pid(), component_id()}
+  @type state() :: %__MODULE__{
+          opts: opts(),
+          cards: %{String.t() => HomeDash.Card.t()},
+          subscriptions: [subscription()]
+        }
+
+  @type cards() :: list(HomeDash.Card.t())
+  @type cards_response() :: {state(), cards(), cards()}
+
+  @enforce_keys [:opts, :cards, :subscriptions]
+  defstruct opts: [], cards: %{}, subscriptions: []
+
+  @spec add_cards(state(), cards()) :: cards_response()
+  def add_cards(state, new_cards) do
+    new_cards_map = new_cards |> Enum.map(&{&1.id, &1}) |> Map.new()
+    cards = Map.merge(state.cards, new_cards_map)
+    state = Map.put(state, :cards, cards)
+
+    {state, new_cards, []}
+  end
+
+  @spec new(opts()) :: state()
+  def new(opts), do: %__MODULE__{opts: opts, cards: %{}, subscriptions: []}
+
+  @spec set_cards(state(), cards()) :: cards_response()
+  def set_cards(state, new_cards) do
+    cards = new_cards |> Enum.map(&{&1.id, &1}) |> Map.new()
+    removed_cards = state.cards |> Map.drop(Map.keys(cards)) |> Map.values()
+
+    state = Map.put(state, :cards, cards)
+
+    {state, new_cards, removed_cards}
+  end
+
+  @spec remove_cards(state(), cards()) :: cards_response()
+  def remove_cards(state, removed_cards) do
+    remove_card_ids =
+      removed_cards
+      |> Enum.map(fn
+        id when is_binary(id) -> id
+        %{id: id} -> id
+      end)
+
+    cards = Map.drop(state.cards, remove_card_ids)
+
+    state = Map.put(state, :cards, cards)
+
+    {state, [], removed_cards}
+  end
+
+  @spec add_subscription(state(), pid(), component_id()) :: state()
+  def add_subscription(state, pid, component_id) when is_pid(pid) and is_binary(component_id) do
+    Map.put(state, :subscriptions, [{pid, component_id} | state.subscriptions])
+  end
+
+  @spec remove_subscription(state(), pid()) :: state()
+  def remove_subscription(state, remove_pid) do
+    subscriptions = Enum.reject(state.subscriptions, fn {pid, _cid} -> pid == remove_pid end)
+
+    Map.put(state, :subscriptions, subscriptions)
+  end
+end

--- a/lib/home_dash/provider/state.ex
+++ b/lib/home_dash/provider/state.ex
@@ -10,19 +10,19 @@ defmodule HomeDash.Provider.State do
   @type opts() :: term()
   @type component_id() :: String.t()
   @type subscription() :: {pid(), component_id()}
-  @type state() :: %__MODULE__{
+  @type t() :: %__MODULE__{
           opts: opts(),
           cards: %{String.t() => HomeDash.Card.t()},
           subscriptions: [subscription()]
         }
 
   @type cards() :: list(HomeDash.Card.t())
-  @type cards_response() :: {state(), cards(), cards()}
+  @type cards_response() :: {t(), cards(), cards()}
 
   @enforce_keys [:opts, :cards, :subscriptions]
   defstruct opts: [], cards: %{}, subscriptions: []
 
-  @spec add_cards(state(), cards()) :: cards_response()
+  @spec add_cards(t(), cards()) :: cards_response()
   def add_cards(state, new_cards) do
     new_cards_map = new_cards |> Enum.map(&{&1.id, &1}) |> Map.new()
     cards = Map.merge(state.cards, new_cards_map)
@@ -31,10 +31,10 @@ defmodule HomeDash.Provider.State do
     {state, new_cards, []}
   end
 
-  @spec new(opts()) :: state()
+  @spec new(opts()) :: t()
   def new(opts), do: %__MODULE__{opts: opts, cards: %{}, subscriptions: []}
 
-  @spec set_cards(state(), cards()) :: cards_response()
+  @spec set_cards(t(), cards()) :: cards_response()
   def set_cards(state, new_cards) do
     cards = new_cards |> Enum.map(&{&1.id, &1}) |> Map.new()
     removed_cards = state.cards |> Map.drop(Map.keys(cards)) |> Map.values()
@@ -44,7 +44,7 @@ defmodule HomeDash.Provider.State do
     {state, new_cards, removed_cards}
   end
 
-  @spec remove_cards(state(), cards()) :: cards_response()
+  @spec remove_cards(t(), cards()) :: cards_response()
   def remove_cards(state, removed_cards) do
     remove_card_ids =
       removed_cards
@@ -60,12 +60,12 @@ defmodule HomeDash.Provider.State do
     {state, [], removed_cards}
   end
 
-  @spec add_subscription(state(), pid(), component_id()) :: state()
+  @spec add_subscription(t(), pid(), component_id()) :: t()
   def add_subscription(state, pid, component_id) when is_pid(pid) and is_binary(component_id) do
     Map.put(state, :subscriptions, [{pid, component_id} | state.subscriptions])
   end
 
-  @spec remove_subscription(state(), pid()) :: state()
+  @spec remove_subscription(t(), pid()) :: t()
   def remove_subscription(state, remove_pid) do
     subscriptions = Enum.reject(state.subscriptions, fn {pid, _cid} -> pid == remove_pid end)
 

--- a/lib/home_dash/provider/state.ex
+++ b/lib/home_dash/provider/state.ex
@@ -35,7 +35,7 @@ defmodule HomeDash.Provider.State do
 
   @spec set_cards(t(), cards()) :: cards_response()
   def set_cards(state, new_cards) do
-    cards = new_cards |> Enum.map(&{&1.id, &1}) |> Map.new()
+    cards = Map.new(new_cards, &{&1.id, &1})
     removed_cards = state.cards |> Map.drop(Map.keys(cards)) |> Map.values()
 
     state = Map.put(state, :cards, cards)

--- a/test/home_dash/provider/state_test.exs
+++ b/test/home_dash/provider/state_test.exs
@@ -1,0 +1,235 @@
+defmodule HomeDash.Provider.StateTest do
+  use ExUnit.Case, async: true
+
+  import HomeDash.Factory
+
+  alias HomeDash.Provider.State
+
+  def state(_context) do
+    {:ok, state: State.new([])}
+  end
+
+  def pids(_context) do
+    {:ok, pid: spawn(fn -> 1 end), other_pid: spawn(fn -> 1 end)}
+  end
+
+  describe "add_cards/2" do
+    setup [:state]
+
+    test "handles empty cards", %{state: state} do
+      new_cards = []
+
+      assert {^state, [], []} = State.add_cards(state, new_cards)
+    end
+
+    test "adds cards to an empty list", %{state: state} do
+      new_cards = [build(:card, id: "1"), build(:card, id: "2")]
+
+      assert {new_state, ^new_cards, []} = State.add_cards(state, new_cards)
+
+      assert assert_cards(new_state, new_cards)
+    end
+
+    test "adds cards to existing cards", %{state: state} do
+      initial_cards = [build(:card, id: "1"), build(:card, id: "2")]
+      state = with_cards(state, initial_cards)
+
+      new_cards = [build(:card, id: "3"), build(:card, id: "4")]
+
+      assert {new_state, ^new_cards, []} = State.add_cards(state, new_cards)
+
+      assert assert_cards(new_state, initial_cards ++ new_cards)
+    end
+
+    test "adds cards to overlapping existing cards", %{state: state} do
+      initial_cards = [build(:card, id: "1"), build(:card, id: "2")]
+      state = with_cards(state, initial_cards)
+
+      new_cards = [build(:card, id: "2"), build(:card, id: "3")]
+
+      assert {new_state, ^new_cards, []} = State.add_cards(state, new_cards)
+
+      assert assert_cards(new_state, initial_cards ++ new_cards)
+    end
+
+    test "prefers new cards to old cards", %{state: state} do
+      initial_cards = [build(:card, id: "1", data: %{title: "Old Data"})]
+      state = with_cards(state, initial_cards)
+
+      new_cards = [build(:card, id: "1", data: %{title: "New Data"}), build(:card, id: "2")]
+
+      assert {new_state, ^new_cards, []} = State.add_cards(state, new_cards)
+
+      assert assert_cards(new_state, new_cards)
+    end
+  end
+
+  describe "set_cards/2" do
+    setup [:state]
+
+    test "sets empty cards", %{state: state} do
+      cards = []
+
+      assert {new_state, [], []} = State.set_cards(state, cards)
+
+      assert assert_cards(new_state, [])
+    end
+
+    test "sets empty cards overides existing cards", %{state: state} do
+      initial_cards = [build(:card, id: "1"), build(:card, id: "2")]
+      state = with_cards(state, initial_cards)
+
+      cards = []
+
+      assert {new_state, [], ^initial_cards} = State.set_cards(state, cards)
+
+      assert assert_cards(new_state, [])
+    end
+
+    test "sets new cards over empty cards", %{state: state} do
+      initial_cards = [build(:card, id: "1"), build(:card, id: "2")]
+      state = with_cards(state, initial_cards)
+
+      cards = [build(:card, id: "1"), build(:card, id: "2")]
+
+      assert {new_state, ^cards, []} = State.set_cards(state, cards)
+
+      assert assert_cards(new_state, cards)
+    end
+
+    test "sets new cards over existing cards", %{state: state} do
+      initial_cards = [build(:card, id: "1"), build(:card, id: "2")]
+      state = with_cards(state, initial_cards)
+
+      cards = [build(:card, id: "3"), build(:card, id: "4")]
+
+      assert {new_state, ^cards, ^initial_cards} = State.set_cards(state, cards)
+
+      assert assert_cards(new_state, cards)
+    end
+
+    test "overrides exisitng cards, prefers exisitng cards", %{state: state} do
+      initial_cards =
+        [_, removed] = [build(:card, id: "1", data: %{title: "Old Data"}), build(:card, id: "2")]
+
+      state = with_cards(state, initial_cards)
+
+      cards = [build(:card, id: "1", data: %{title: "Old Data"}), build(:card, id: "3")]
+
+      assert {new_state, ^cards, [^removed]} = State.set_cards(state, cards)
+
+      assert assert_cards(new_state, cards)
+    end
+  end
+
+  describe "remove_cards/2" do
+    setup [:state]
+
+    test "handles empty lists", %{state: state} do
+      cards = []
+
+      assert {^state, [], []} = State.remove_cards(state, cards)
+    end
+
+    test "removes existing cards ", %{state: state} do
+      initial_cards =
+        [first, second, third] = [
+          build(:card, id: "1"),
+          build(:card, id: "2"),
+          build(:card, id: "3")
+        ]
+
+      state = with_cards(state, initial_cards)
+
+      cards = [first, third]
+
+      assert {new_state, [], ^cards} = State.remove_cards(state, cards)
+
+      assert assert_cards(new_state, second)
+    end
+
+    test "egnores non-existing cards ", %{state: state} do
+      initial_cards =
+        [first, second] = [build(:card, id: "1"), build(:card, id: "2")]
+
+      state = with_cards(state, initial_cards)
+
+      cards = [first, build(:card, id: "3")]
+
+      assert {new_state, [], ^cards} = State.remove_cards(state, cards)
+
+      assert assert_cards(new_state, second)
+    end
+  end
+
+  describe "add_subscription/3" do
+    setup [:state, :pids]
+
+    test "adds a subscription", %{state: state, pid: pid} do
+      new_state = State.add_subscription(state, pid, "component_id")
+
+      assert new_state.subscriptions == [{pid, "component_id"}]
+    end
+
+    test "adds duplicate subscription pids", %{state: state, pid: pid} do
+      new_state =
+        state
+        |> State.add_subscription(pid, "component_id")
+        |> State.add_subscription(pid, "other_id")
+
+      assert new_state.subscriptions == [{pid, "other_id"}, {pid, "component_id"}]
+    end
+  end
+
+  describe "remove_subscription/2" do
+    setup [:state, :pids]
+
+    test "removes a subscription", %{state: state, pid: pid} do
+      new_state =
+        state
+        |> State.add_subscription(pid, "component_id")
+        |> State.remove_subscription(pid)
+
+      assert new_state.subscriptions == []
+    end
+
+    test "removes duplicate subscription pids", %{state: state, pid: pid} do
+      new_state =
+        state
+        |> State.add_subscription(pid, "component_id")
+        |> State.add_subscription(pid, "other_id")
+        |> State.remove_subscription(pid)
+
+      assert new_state.subscriptions == []
+    end
+
+    test "ignores non-existent pids", %{state: state, pid: pid, other_pid: other_pid} do
+      new_state =
+        state
+        |> State.add_subscription(pid, "component_id")
+        |> State.remove_subscription(other_pid)
+
+      assert new_state.subscriptions == [{pid, "component_id"}]
+    end
+  end
+
+  defp assert_cards(state, cards) do
+    state_keys = Map.keys(state.cards)
+
+    keys =
+      cards
+      |> List.wrap()
+      |> Enum.map(fn
+        card ->
+          assert card.id in state_keys
+          assert state.cards[card.id] == card
+          card
+      end)
+      |> Enum.map(fn card ->
+        card.id
+      end)
+
+    remaining_cards = Map.drop(state.cards, keys)
+    assert Map.equal?(remaining_cards, %{})
+  end
+end

--- a/test/home_dash/provider_test.exs
+++ b/test/home_dash/provider_test.exs
@@ -1,5 +1,5 @@
 defmodule HomeDash.ProviderTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   import HomeDash.Factory
 
@@ -19,7 +19,7 @@ defmodule HomeDash.ProviderTest do
   end
 
   def genserver(_context) do
-    {:ok, pid} = TestProvider.start_link([])
+    {:ok, pid} = TestProvider.start_link(server_name: __MODULE__)
     {:ok, pid: pid}
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -18,7 +18,7 @@ defmodule HomeDash.Factory do
   end
 
   def with_cards(%State{} = state, cards) do
-    cards_map = cards |> Enum.map(&{&1.id, &1}) |> Map.new()
+    cards_map = Map.new(cards, &{&1.id, &1})
     %{state | cards: cards_map}
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1,6 +1,7 @@
 defmodule HomeDash.Factory do
   use ExMachina
   alias HomeDash.Card
+  alias HomeDash.Provider.State
 
   def card_factory do
     %Card{
@@ -10,5 +11,18 @@ defmodule HomeDash.Factory do
       order: 1,
       data: %{title: "My Test Card"}
     }
+  end
+
+  def state_factory do
+    %State{
+      opts: [],
+      cards: %{},
+      subscriptions: []
+    }
+  end
+
+  def with_cards(%State{} = state, cards) do
+    cards_map = cards |> Enum.map(&{&1.id, &1}) |> Map.new()
+    %{state | cards: cards_map}
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -14,11 +14,7 @@ defmodule HomeDash.Factory do
   end
 
   def state_factory do
-    %State{
-      opts: [],
-      cards: %{},
-      subscriptions: []
-    }
+    %State{}
   end
 
   def with_cards(%State{} = state, cards) do


### PR DESCRIPTION
Moves state management for providers into `Provider.State`. Easier to test state transitions when we do not have to interact with the process.